### PR TITLE
Update bump-version script to handle README download URLs

### DIFF
--- a/commands/bump-version.ps1
+++ b/commands/bump-version.ps1
@@ -48,6 +48,18 @@ $VersionFiles = @(
         Pattern     = 'public const string Version = "[\d\.]+";'
         Replace     = 'public const string Version = "{VERSION}";'
         Description = "Installer C# version constant"
+    },
+    @{
+        Path        = "Unity-Package/Assets/root/README.md"
+        Pattern     = "https://github\.com/IvanMurzak/Unity-AI-Animation/releases/download/[\d\.]+/YOUR_PACKAGE_NAME_INSTALLER_FILE\.unitypackage"
+        Replace     = "https://github.com/IvanMurzak/Unity-AI-Animation/releases/download/{VERSION}/YOUR_PACKAGE_NAME_INSTALLER_FILE.unitypackage"
+        Description = "Package README download URL"
+    },
+    @{
+        Path        = "README.md"
+        Pattern     = "https://github\.com/IvanMurzak/Unity-AI-Animation/releases/download/[\d\.]+/YOUR_PACKAGE_NAME_INSTALLER_FILE\.unitypackage"
+        Replace     = "https://github.com/IvanMurzak/Unity-AI-Animation/releases/download/{VERSION}/YOUR_PACKAGE_NAME_INSTALLER_FILE.unitypackage"
+        Description = "Repository README download URL"
     }
 )
 


### PR DESCRIPTION
Added patterns to update the package and repository README.md download URLs with the correct version during the bump-version process. This ensures that release links in documentation are automatically updated.