### PR TITLE
ci: add disk cleanup step to test workflow

### DIFF
--- a/.github/workflows/release.yml-sample
+++ b/.github/workflows/release.yml-sample
@@ -47,6 +47,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Cache Unity Library
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -56,7 +56,20 @@ jobs:
           lfs: false
 
       # --------------------------------------------------------------------- #
-      # 2-c. Cache & run the Unity test-runner
+      # 2-c. Free disk space
+      # --------------------------------------------------------------------- #
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      # --------------------------------------------------------------------- #
+      # 2-d. Cache & run the Unity test-runner
       # --------------------------------------------------------------------- #
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- Added `jlumbroso/free-disk-space@main` step to `test_unity_plugin.yml` after checkout and before cache/test steps
- Removes Android, .NET, Haskell, large packages, and swap storage to free disk space
- Matches the same cleanup applied in IvanMurzak/Unity-MCP#620

## Test plan
- [ ] CI runs successfully with the new disk cleanup step
- [ ] Verify disk space is sufficient for Unity test runner

Closes #8